### PR TITLE
Fix navigation to battle screen

### DIFF
--- a/app/lib/features/create/view/create_char_screen.dart
+++ b/app/lib/features/create/view/create_char_screen.dart
@@ -7,6 +7,7 @@ import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_container.dart';
 import 'package:app/features/create/model/create_char_model.dart';
 import 'package:app/features/create/view_model/create_char_view_model.dart';
+import 'package:app/features/battle/view/single_battle_patterns_screen.dart';
 
 class CreateCharacterScreen extends ConsumerStatefulWidget {
   const CreateCharacterScreen({Key? key}) : super(key: key);
@@ -237,6 +238,12 @@ class CharacterCreationSuccessPage extends StatelessWidget {
             ElevatedButton(
               onPressed: () {
                 Navigator.popUntil(context, (route) => route.isFirst);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const SingleBattlePatternsScreen(),
+                  ),
+                );
               },
               child: const Text('バトルへ'),
             ),


### PR DESCRIPTION
## Summary
- ensure "Battle" button after character creation navigates to battle setup

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa04b03c48321927017eab0435a64