### PR TITLE
Fix rewarded ad loading

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -16,6 +16,9 @@ void main() async {
   // AdMobの初期化
   await MobileAds.instance.initialize();
 
+  // リワード広告を読み込む
+  RewardAdHelper.loadRewardedAd();
+
   // 初回起動判定
   final prefs = await SharedPreferences.getInstance();
   final isFirstLaunch = prefs.getBool('isFirstLaunch') ?? true;
@@ -133,7 +136,8 @@ class RewardAdHelper {
       _rewardedAd = null;
       loadRewardedAd(); // 次の広告も読み込んでおく
     } else {
-      print('広告がまだ読み込まれていません');
+      print('広告がまだ読み込まれていません。再読み込みします');
+      loadRewardedAd();
     }
   }
 


### PR DESCRIPTION
## Summary
- アプリ起動時にリワード広告を読み込むよう追加
- 広告未読み込み時にボタンを押した場合、再読み込みするよう修正

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fab9bc1008321a94c74adf41b13e7