### PR TITLE
Fix missing import for battle patterns

### DIFF
--- a/app/lib/features/create/view/create_char_screen.dart
+++ b/app/lib/features/create/view/create_char_screen.dart
@@ -7,6 +7,7 @@ import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_container.dart';
 import 'package:app/features/create/model/create_char_model.dart';
 import 'package:app/features/create/view_model/create_char_view_model.dart';
+import 'package:app/features/battle/view/single_battle_patterns_screen.dart';
 
 class CreateCharacterScreen extends ConsumerStatefulWidget {
   const CreateCharacterScreen({Key? key}) : super(key: key);
@@ -236,7 +237,12 @@ class CharacterCreationSuccessPage extends StatelessWidget {
             const SizedBox(height: 10),
             ElevatedButton(
               onPressed: () {
-                Navigator.popUntil(context, (route) => route.isFirst);
+                Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const SingleBattlePatternsScreen(),
+                  ),
+                );
               },
               child: const Text('バトルへ'),
             ),


### PR DESCRIPTION
## Summary
- add missing import for `SingleBattlePatternsScreen`
- navigate to `SingleBattlePatternsScreen` after creating a character

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683faec0725c8321b63fa16820fd0332