### PR TITLE
Apply Neumorphic UI widgets

### DIFF
--- a/app/lib/features/auth/view/auth_screen.dart
+++ b/app/lib/features/auth/view/auth_screen.dart
@@ -5,6 +5,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../home/view/home_screen.dart';
 import 'package:app/features/auth/view/widget/signup_dialog.dart';
 import '../../home/view_model/home_view_model.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 
 class AuthScreen extends ConsumerWidget {
   const AuthScreen({super.key});
@@ -30,7 +31,8 @@ class AuthScreen extends ConsumerWidget {
               // モーダルを開くボタン
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
+                child: NeumorphicButton(
+                  padding: EdgeInsets.symmetric(vertical: 12.h),
                   onPressed: () {
                     // showDialogを使ってモーダルを開く
                     showDialog(
@@ -38,12 +40,9 @@ class AuthScreen extends ConsumerWidget {
                       builder: (_) => const SignupDialog(),
                     );
                   },
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: 12.h),
-                    child: Text(
-                      'メールアドレスで登録',
-                      style: TextStyle(fontSize: 16.sp),
-                    ),
+                  child: Text(
+                    'メールアドレスで登録',
+                    style: TextStyle(fontSize: 16.sp),
                   ),
                 ),
               ),
@@ -52,7 +51,8 @@ class AuthScreen extends ConsumerWidget {
               // 引き継ぎ
               SizedBox(
                 width: double.infinity,
-                child: ElevatedButton(
+                child: NeumorphicButton(
+                  padding: EdgeInsets.symmetric(vertical: 12.h),
                   onPressed: () {
                     // showDialogを使ってモーダルを開く
                     showDialog(
@@ -60,19 +60,20 @@ class AuthScreen extends ConsumerWidget {
                       builder: (_) => const SignupDialog(),
                     );
                   },
-                  child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: 12.h),
-                    child: Text(
-                      'アカウントを引き継ぐ',
-                      style: TextStyle(fontSize: 16.sp),
-                    ),
+                  child: Text(
+                    'アカウントを引き継ぐ',
+                    style: TextStyle(fontSize: 16.sp),
                   ),
                 ),
               ),
               SizedBox(height: 16.h),
 
               // スキップボタン
-              TextButton(
+              NeumorphicButton(
+                padding: EdgeInsets.symmetric(
+                  horizontal: 16.w,
+                  vertical: 8.h,
+                ),
                 onPressed: () {
                   // HomeScreenへ遷移前にチュートリアル初期化
                   ref.read(homeViewModelProvider.notifier).initializeTutorial();

--- a/app/lib/features/auth/view/widget/signup_dialog.dart
+++ b/app/lib/features/auth/view/widget/signup_dialog.dart
@@ -5,6 +5,7 @@ import 'package:app/features/auth/view_model/auth_view_model.dart';
 import '../../../home/view/home_screen.dart';
 import '../../../home/view_model/home_view_model.dart';
 import 'package:app/features/auth/view_model/terminal_id_view_model.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 
 class SignupDialog extends ConsumerStatefulWidget {
   const SignupDialog({Key? key}) : super(key: key);
@@ -82,7 +83,8 @@ class _SignupDialogState extends ConsumerState<SignupDialog> {
       ),
       actions: [
         // キャンセルボタン
-        TextButton(
+        NeumorphicButton(
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
           onPressed: authState.isLoading
               ? null
               : () {
@@ -93,7 +95,8 @@ class _SignupDialogState extends ConsumerState<SignupDialog> {
         ),
 
         // 登録ボタン
-        ElevatedButton(
+        NeumorphicButton(
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
           onPressed: authState.isLoading
               ? null
               : () async {

--- a/app/lib/features/home/view/tabs/home_tab.dart
+++ b/app/lib/features/home/view/tabs/home_tab.dart
@@ -257,25 +257,19 @@ class HomeTab extends ConsumerWidget {
     };
 
     if (battleFlg == 2) {
-      return TextButton(
+      return NeumorphicButton(
+        padding: EdgeInsets.symmetric(
+          horizontal: 18.w,
+          vertical: 12.h,
+        ),
         onPressed: () {
           // バトル終了後の処理（結果を見る画面へ）
           print('バトル終了ボタン押下');
         },
-        style: TextButton.styleFrom(
-          backgroundColor: Colors.green,
-          padding: EdgeInsets.symmetric(
-            horizontal: 18.w,
-            vertical: 12.h,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16.r),
-          ),
-        ),
         child: Text(
           battleStatusMap[battleFlg]!,
           style: TextStyle(
-            color: Colors.white,
+            color: Colors.green,
             fontWeight: FontWeight.bold,
             fontSize: 16.sp,
           ),

--- a/app/lib/features/home/view/widget/edit_profile_dialog.dart
+++ b/app/lib/features/home/view/widget/edit_profile_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 
 class EditProfileDialog extends StatefulWidget {
   final String title;
@@ -82,11 +83,13 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
         ),
       ),
       actions: [
-        TextButton(
+        NeumorphicButton(
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
           onPressed: () => Navigator.pop(context),
           child: const Text("キャンセル"),
         ),
-        ElevatedButton(
+        NeumorphicButton(
+          padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
           onPressed: (!isInputValid || !_hasChanges)
               ? null // 無効な入力または変更がない場合は無効化
               : () {

--- a/app/lib/features/onboarding/view/onboarding_screen.dart
+++ b/app/lib/features/onboarding/view/onboarding_screen.dart
@@ -6,6 +6,7 @@ import 'package:app/features/auth/view/auth_screen.dart';
 import 'package:app/features/onboarding/view_model/onboarding_view_model.dart';
 import 'package:app/features/onboarding/view/onboarding_page.dart';
 import 'package:app/features/onboarding/model/onboarding_content.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 
 class OnboardingScreen extends ConsumerStatefulWidget {
   const OnboardingScreen({super.key});
@@ -94,7 +95,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                       ),
                     ),
                   ),
-                  TextButton(
+                  NeumorphicButton(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: 16.w,
+                      vertical: 8.h,
+                    ),
                     onPressed: _onNextPressed,
                     child: Text(
                       currentPage < pages.length - 1 ? '次へ' : '始める',


### PR DESCRIPTION
## Summary
- replace Material buttons with `NeumorphicButton`
- use neumorphic style on onboarding and auth flows
- update profile dialogs and battle status button for consistency

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb3e7d8dc8321aa559b31d244e1df