### PR TITLE
Add email and password update dialogs

### DIFF
--- a/app/lib/features/home/view/tabs/profile_tab.dart
+++ b/app/lib/features/home/view/tabs/profile_tab.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../view_model/profile_view_model.dart';
 import '../../view_model/home_view_model.dart';
-import '../widget/edit_profile_dialog.dart';
+import '../widget/account_settings_dialog.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_container.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 
@@ -55,13 +55,7 @@ class _ProfileTabState extends ConsumerState<ProfileTab> {
                 onPressed: () {
                   showDialog(
                     context: context,
-                    builder: (_) => EditProfileDialog(
-                      title: 'ユーザー登録情報変更',
-                      currentValue: profile.username,
-                      onSave: (value) {
-                        profileNotifier.updateProfile(value, profile.bio);
-                      },
-                    ),
+                    builder: (_) => const AccountSettingsDialog(),
                   );
                 },
                 child: Text('ユーザー登録情報変更', style: TextStyle(fontSize: 16.sp)),

--- a/app/lib/features/home/view/widget/account_settings_dialog.dart
+++ b/app/lib/features/home/view/widget/account_settings_dialog.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../../view_model/profile_view_model.dart';
+import 'change_email_dialog.dart';
+import 'change_password_dialog.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
+
+class AccountSettingsDialog extends ConsumerWidget {
+  const AccountSettingsDialog({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final email = ref.watch(profileViewModelProvider).email;
+
+    return AlertDialog(
+      title: const Text('ユーザー登録情報変更'),
+      content: SizedBox(
+        width: 300.w,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('現在のメールアドレス: $email'),
+            SizedBox(height: 24.h),
+            NeumorphicButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                showDialog(
+                  context: context,
+                  builder: (_) => const ChangeEmailDialog(),
+                );
+              },
+              child: const Text('メールアドレスを変更'),
+            ),
+            SizedBox(height: 16.h),
+            NeumorphicButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                showDialog(
+                  context: context,
+                  builder: (_) => const ChangePasswordDialog(),
+                );
+              },
+              child: const Text('パスワードを変更'),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        NeumorphicButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('閉じる'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/home/view/widget/change_email_dialog.dart
+++ b/app/lib/features/home/view/widget/change_email_dialog.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../../view_model/profile_view_model.dart';
+import '../../view_model/home_view_model.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
+
+class ChangeEmailDialog extends ConsumerStatefulWidget {
+  const ChangeEmailDialog({super.key});
+
+  @override
+  ConsumerState<ChangeEmailDialog> createState() => _ChangeEmailDialogState();
+}
+
+class _ChangeEmailDialogState extends ConsumerState<ChangeEmailDialog> {
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final profileState = ref.watch(profileViewModelProvider);
+    final notifier = ref.read(profileViewModelProvider.notifier);
+    final userId = ref.watch(homeViewModelProvider).userId;
+
+    return AlertDialog(
+      title: const Text('メールアドレスを変更'),
+      content: SizedBox(
+        width: 300.w,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: '新しいメールアドレス'),
+            ),
+            SizedBox(height: 16.h),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: '現在のパスワード'),
+              obscureText: true,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        NeumorphicButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('キャンセル'),
+        ),
+        NeumorphicButton(
+          onPressed: profileState.isLoading
+              ? null
+              : () async {
+                  final newEmail = _emailController.text.trim();
+                  final password = _passwordController.text.trim();
+                  if (userId != null && newEmail.isNotEmpty && password.isNotEmpty) {
+                    final success = await notifier.changeEmail(
+                      userId: userId,
+                      password: password,
+                      newEmail: newEmail,
+                    );
+                    if (success && mounted) {
+                      Navigator.pop(context);
+                    }
+                  }
+                },
+          child: profileState.isLoading
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('保存'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/home/view/widget/change_password_dialog.dart
+++ b/app/lib/features/home/view/widget/change_password_dialog.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import '../../view_model/profile_view_model.dart';
+import '../../view_model/home_view_model.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
+
+class ChangePasswordDialog extends ConsumerStatefulWidget {
+  const ChangePasswordDialog({super.key});
+
+  @override
+  ConsumerState<ChangePasswordDialog> createState() => _ChangePasswordDialogState();
+}
+
+class _ChangePasswordDialogState extends ConsumerState<ChangePasswordDialog> {
+  final _oldPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _oldPasswordController.dispose();
+    _newPasswordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final profileState = ref.watch(profileViewModelProvider);
+    final notifier = ref.read(profileViewModelProvider.notifier);
+    final userId = ref.watch(homeViewModelProvider).userId;
+
+    return AlertDialog(
+      title: const Text('パスワードを変更'),
+      content: SizedBox(
+        width: 300.w,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: _oldPasswordController,
+              decoration: const InputDecoration(labelText: '現在のパスワード'),
+              obscureText: true,
+            ),
+            SizedBox(height: 16.h),
+            TextField(
+              controller: _newPasswordController,
+              decoration: const InputDecoration(labelText: '新しいパスワード'),
+              obscureText: true,
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        NeumorphicButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('キャンセル'),
+        ),
+        NeumorphicButton(
+          onPressed: profileState.isLoading
+              ? null
+              : () async {
+                  final oldPass = _oldPasswordController.text.trim();
+                  final newPass = _newPasswordController.text.trim();
+                  if (userId != null && oldPass.isNotEmpty && newPass.isNotEmpty) {
+                    final success = await notifier.changePassword(
+                      userId: userId,
+                      oldPassword: oldPass,
+                      newPassword: newPass,
+                    );
+                    if (success && mounted) {
+                      Navigator.pop(context);
+                    }
+                  }
+                },
+          child: profileState.isLoading
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('保存'),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/features/home/view_model/profile_view_model.dart
+++ b/app/lib/features/home/view_model/profile_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import '../model/profile_state.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:http/http.dart' as http;
 
 class ProfileViewModel extends StateNotifier<ProfileState> {
   final ImagePicker _imagePicker = ImagePicker();
@@ -98,6 +99,86 @@ class ProfileViewModel extends StateNotifier<ProfileState> {
         isLoading: false,
         errorMessage: "メールアドレスの更新に失敗しました。",
       );
+    }
+  }
+
+  // メールアドレス変更API呼び出し
+  Future<bool> changeEmail({
+    required int userId,
+    required String password,
+    required String newEmail,
+  }) async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final uri = Uri.parse('http://localhost:8000/update/update_email');
+      final response = await http.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'user_id': userId,
+          'password': password,
+          'new_email': newEmail,
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.setString('email', newEmail);
+        state = state.copyWith(email: newEmail, isLoading: false);
+        return true;
+      } else {
+        final body = jsonDecode(response.body);
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: body['detail'] ?? 'メールアドレスの更新に失敗しました。',
+        );
+        return false;
+      }
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'メールアドレスの更新に失敗しました。',
+      );
+      return false;
+    }
+  }
+
+  // パスワード変更API呼び出し
+  Future<bool> changePassword({
+    required int userId,
+    required String oldPassword,
+    required String newPassword,
+  }) async {
+    state = state.copyWith(isLoading: true, errorMessage: null);
+    try {
+      final uri = Uri.parse('http://localhost:8000/update/update_password');
+      final response = await http.post(
+        uri,
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({
+          'user_id': userId,
+          'old_password': oldPassword,
+          'new_password': newPassword,
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        state = state.copyWith(isLoading: false);
+        return true;
+      } else {
+        final body = jsonDecode(response.body);
+        state = state.copyWith(
+          isLoading: false,
+          errorMessage: body['detail'] ?? 'パスワードの更新に失敗しました。',
+        );
+        return false;
+      }
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        errorMessage: 'パスワードの更新に失敗しました。',
+      );
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- add AccountSettingsDialog with options to change email or password
- add ChangeEmailDialog and ChangePasswordDialog for user input and API calls
- implement changeEmail and changePassword in ProfileViewModel
- open AccountSettingsDialog from ProfileTab

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424b9b230c83219746eb7388af69f0