### PR TITLE
Fix username update API call

### DIFF
--- a/app/lib/features/home/view_model/profile_view_model.dart
+++ b/app/lib/features/home/view_model/profile_view_model.dart
@@ -106,12 +106,15 @@ class ProfileViewModel extends StateNotifier<ProfileState> {
       final isGuest = newUsername == 'ゲスト';
       await prefs.setBool('isGuest', isGuest);
 
+      final isProfileComplete =
+          state.copyWith(username: newUsername).hasCompleteProfile;
+
       state = state.copyWith(
         username: newUsername,
         isGuest: isGuest,
         lastUpdated: now,
         isLoading: false,
-        isProfileComplete: state.hasCompleteProfile,
+        isProfileComplete: isProfileComplete,
       );
     } catch (e) {
       state = state.copyWith(


### PR DESCRIPTION
## Summary
- revert username update to use localhost API URL
- compute profile completeness after saving the new username
- remove unused `api_utils` helper

## Testing
- `git show -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684260e6f66c8321be9abee4b30d2e10