### PR TITLE
Display responses after updating account info

### DIFF
--- a/app/lib/features/home/view/tabs/profile_tab.dart
+++ b/app/lib/features/home/view/tabs/profile_tab.dart
@@ -62,9 +62,22 @@ class _ProfileTabState extends ConsumerState<ProfileTab> {
                                 builder: (_) => EditProfileDialog(
                                   title: 'ユーザー名編集',
                                   currentValue: profile.username,
-                                  onSave: (value) {
+                                  onSave: (value) async {
                                     if (userId != null) {
-                                      profileNotifier.updateUsername(userId, value);
+                                      final success = await profileNotifier
+                                          .updateUsername(userId, value);
+                                      final updated =
+                                          ref.read(profileViewModelProvider);
+                                      ScaffoldMessenger.of(context).showSnackBar(
+                                        SnackBar(
+                                          content: Text(
+                                            success
+                                                ? 'ユーザー名を更新しました'
+                                                : updated.errorMessage ??
+                                                    'ユーザー名の更新に失敗しました',
+                                          ),
+                                        ),
+                                      );
                                     }
                                   },
                                 ),

--- a/app/lib/features/home/view/widget/change_email_dialog.dart
+++ b/app/lib/features/home/view/widget/change_email_dialog.dart
@@ -60,14 +60,27 @@ class _ChangeEmailDialogState extends ConsumerState<ChangeEmailDialog> {
               : () async {
                   final newEmail = _emailController.text.trim();
                   final password = _passwordController.text.trim();
-                  if (userId != null && newEmail.isNotEmpty && password.isNotEmpty) {
+                  if (userId != null &&
+                      newEmail.isNotEmpty &&
+                      password.isNotEmpty) {
                     final success = await notifier.changeEmail(
                       userId: userId,
                       password: password,
                       newEmail: newEmail,
                     );
-                    if (success && mounted) {
+                    final updated = ref.read(profileViewModelProvider);
+                    if (mounted) {
                       Navigator.pop(context);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            success
+                                ? 'メールアドレスを変更しました'
+                                : updated.errorMessage ??
+                                    'メールアドレスの変更に失敗しました',
+                          ),
+                        ),
+                      );
                     }
                   }
                 },

--- a/app/lib/features/home/view/widget/change_password_dialog.dart
+++ b/app/lib/features/home/view/widget/change_password_dialog.dart
@@ -61,14 +61,27 @@ class _ChangePasswordDialogState extends ConsumerState<ChangePasswordDialog> {
               : () async {
                   final oldPass = _oldPasswordController.text.trim();
                   final newPass = _newPasswordController.text.trim();
-                  if (userId != null && oldPass.isNotEmpty && newPass.isNotEmpty) {
+                  if (userId != null &&
+                      oldPass.isNotEmpty &&
+                      newPass.isNotEmpty) {
                     final success = await notifier.changePassword(
                       userId: userId,
                       oldPassword: oldPass,
                       newPassword: newPass,
                     );
-                    if (success && mounted) {
+                    final updated = ref.read(profileViewModelProvider);
+                    if (mounted) {
                       Navigator.pop(context);
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            success
+                                ? 'パスワードを変更しました'
+                                : updated.errorMessage ??
+                                    'パスワードの変更に失敗しました',
+                          ),
+                        ),
+                      );
                     }
                   }
                 },

--- a/app/lib/features/home/view/widget/edit_profile_dialog.dart
+++ b/app/lib/features/home/view/widget/edit_profile_dialog.dart
@@ -5,7 +5,7 @@ import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 class EditProfileDialog extends StatefulWidget {
   final String title;
   final String currentValue;
-  final Function(String) onSave;
+  final Future<void> Function(String) onSave;
 
   const EditProfileDialog({
     Key? key,
@@ -91,10 +91,12 @@ class _EditProfileDialogState extends State<EditProfileDialog> {
         NeumorphicButton(
           padding: EdgeInsets.symmetric(horizontal: 16.w, vertical: 8.h),
           onPressed: (!isInputValid || !_hasChanges)
-              ? null // 無効な入力または変更がない場合は無効化
-              : () {
-                  widget.onSave(inputText);
-                  Navigator.pop(context);
+              ? null
+              : () async {
+                  await widget.onSave(inputText);
+                  if (mounted) {
+                    Navigator.pop(context);
+                  }
                 },
           child: const Text("保存"),
         ),

--- a/app/lib/features/home/view_model/profile_view_model.dart
+++ b/app/lib/features/home/view_model/profile_view_model.dart
@@ -81,7 +81,7 @@ class ProfileViewModel extends StateNotifier<ProfileState> {
   }
 
   /// ユーザー名のみを更新する（API & ローカル保存）
-  Future<void> updateUsername(int userId, String newUsername) async {
+  Future<bool> updateUsername(int userId, String newUsername) async {
     state = state.copyWith(isLoading: true, errorMessage: null);
     try {
       final uri = Uri.parse('http://localhost:8000/update/update_username');
@@ -113,11 +113,13 @@ class ProfileViewModel extends StateNotifier<ProfileState> {
         isLoading: false,
         isProfileComplete: state.hasCompleteProfile,
       );
+      return true;
     } catch (e) {
       state = state.copyWith(
         isLoading: false,
         errorMessage: "ユーザー名の更新に失敗しました。",
       );
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- show a snackbar after email or password is changed
- wait for username updates and show result
- allow async `onSave` in edit profile dialog
- return success flag from username update

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842adc425e48321ade59ab503651443