### PR TITLE
Show email & password on profile tab

### DIFF
--- a/app/lib/features/home/view/tabs/profile_tab.dart
+++ b/app/lib/features/home/view/tabs/profile_tab.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import '../../view_model/profile_view_model.dart';
 import '../../view_model/home_view_model.dart';
-import '../widget/account_settings_dialog.dart';
+import '../widget/change_email_dialog.dart';
+import '../widget/change_password_dialog.dart';
 import '../widget/edit_profile_dialog.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_container.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
@@ -41,51 +42,101 @@ class _ProfileTabState extends ConsumerState<ProfileTab> {
             children: [
               NeumorphicContainer(
                 padding: EdgeInsets.all(16.w),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                child: Column(
                   children: [
-                    Text('ユーザー名', style: TextStyle(fontSize: 16.sp)),
                     Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
-                        Text(
-                          profile.username.isEmpty ? 'ゲスト' : profile.username,
-                          style: TextStyle(fontSize: 16.sp, fontWeight: FontWeight.bold),
+                        Text('ユーザー名', style: TextStyle(fontSize: 16.sp)),
+                        Row(
+                          children: [
+                            Text(
+                              profile.username.isEmpty ? 'ゲスト' : profile.username,
+                              style: TextStyle(fontSize: 16.sp, fontWeight: FontWeight.bold),
+                            ),
+                            SizedBox(width: 8.w),
+                            NeumorphicContainer(
+                              radius: 20,
+                              child: IconButton(
+                                icon: const Icon(Icons.edit),
+                                onPressed: () {
+                                  showDialog(
+                                    context: context,
+                                    builder: (_) => EditProfileDialog(
+                                      title: 'ユーザー名編集',
+                                      currentValue: profile.username,
+                                      onSave: (value) {
+                                        if (userId != null) {
+                                          profileNotifier.updateUsername(userId, value);
+                                        }
+                                      },
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
                         ),
-                        SizedBox(width: 8.w),
-                        NeumorphicContainer(
-                          radius: 20,
-                          child: IconButton(
-                            icon: const Icon(Icons.edit),
-                            onPressed: () {
-                              showDialog(
-                                context: context,
-                                builder: (_) => EditProfileDialog(
-                                  title: 'ユーザー名編集',
-                                  currentValue: profile.username,
-                                  onSave: (value) {
-                                    if (userId != null) {
-                                      profileNotifier.updateUsername(userId, value);
-                                    }
-                                  },
-                                ),
-                              );
-                            },
-                          ),
+                      ],
+                    ),
+                    SizedBox(height: 16.h),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text('メールアドレス', style: TextStyle(fontSize: 16.sp)),
+                        Row(
+                          children: [
+                            Text(
+                              profile.email,
+                              style: TextStyle(fontSize: 16.sp, fontWeight: FontWeight.bold),
+                            ),
+                            SizedBox(width: 8.w),
+                            NeumorphicContainer(
+                              radius: 20,
+                              child: IconButton(
+                                icon: const Icon(Icons.edit),
+                                onPressed: () {
+                                  showDialog(
+                                    context: context,
+                                    builder: (_) => const ChangeEmailDialog(),
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                    SizedBox(height: 16.h),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text('パスワード', style: TextStyle(fontSize: 16.sp)),
+                        Row(
+                          children: [
+                            Text(
+                              '*****',
+                              style: TextStyle(fontSize: 16.sp, fontWeight: FontWeight.bold),
+                            ),
+                            SizedBox(width: 8.w),
+                            NeumorphicContainer(
+                              radius: 20,
+                              child: IconButton(
+                                icon: const Icon(Icons.edit),
+                                onPressed: () {
+                                  showDialog(
+                                    context: context,
+                                    builder: (_) => const ChangePasswordDialog(),
+                                  );
+                                },
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                     ),
                   ],
                 ),
-              ),
-              SizedBox(height: 24.h),
-              NeumorphicButton(
-                onPressed: () {
-                  showDialog(
-                    context: context,
-                    builder: (_) => const AccountSettingsDialog(),
-                  );
-                },
-                child: Text('ユーザー登録情報変更', style: TextStyle(fontSize: 16.sp)),
               ),
               SizedBox(height: 24.h),
               NeumorphicContainer(


### PR DESCRIPTION
## Summary
- show email and password fields in the profile tab
- open change dialogs directly from edit icons

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537749e3ec8321945dc993370efea2