### PR TITLE
Handle incorrect password on email/password change

### DIFF
--- a/app/lib/features/home/view_model/profile_view_model.dart
+++ b/app/lib/features/home/view_model/profile_view_model.dart
@@ -174,9 +174,17 @@ class ProfileViewModel extends StateNotifier<ProfileState> {
         return true;
       } else {
         final body = jsonDecode(response.body);
+        final detail = body['detail']?.toString() ?? '';
+        final isPasswordError = response.statusCode == 401 ||
+            detail.contains('password') ||
+            detail.contains('パスワード');
         state = state.copyWith(
           isLoading: false,
-          errorMessage: body['detail'] ?? 'メールアドレスの更新に失敗しました。',
+          errorMessage: isPasswordError
+              ? 'パスワードが間違っています'
+              : detail.isNotEmpty
+                  ? detail
+                  : 'メールアドレスの更新に失敗しました。',
         );
         return false;
       }
@@ -213,9 +221,17 @@ class ProfileViewModel extends StateNotifier<ProfileState> {
         return true;
       } else {
         final body = jsonDecode(response.body);
+        final detail = body['detail']?.toString() ?? '';
+        final isPasswordError = response.statusCode == 401 ||
+            detail.contains('password') ||
+            detail.contains('パスワード');
         state = state.copyWith(
           isLoading: false,
-          errorMessage: body['detail'] ?? 'パスワードの更新に失敗しました。',
+          errorMessage: isPasswordError
+              ? 'パスワードが間違っています'
+              : detail.isNotEmpty
+                  ? detail
+                  : 'パスワードの更新に失敗しました。',
         );
         return false;
       }


### PR DESCRIPTION
## Summary
- show a specific error when the password is wrong during email or password change
- keep profile data unchanged on failure

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853caaccb748321a8fd4af291b48f22