### PR TITLE
Implement point exchange modal

### DIFF
--- a/app/lib/features/home/view/tabs/profile_tab.dart
+++ b/app/lib/features/home/view/tabs/profile_tab.dart
@@ -6,6 +6,7 @@ import '../../view_model/home_view_model.dart';
 import '../widget/change_email_dialog.dart';
 import '../widget/change_password_dialog.dart';
 import '../widget/edit_profile_dialog.dart';
+import '../widget/exchange_point_modal.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_container.dart';
 import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
 
@@ -154,8 +155,24 @@ class _ProfileTabState extends ConsumerState<ProfileTab> {
               SizedBox(
                 width: double.infinity,
                 child: NeumorphicButton(
-                  onPressed: () {
-                    // ポイント交換処理
+                  onPressed: () async {
+                    final exchanged = await showDialog<int>(
+                      context: context,
+                      barrierDismissible: true,
+                      barrierColor: Colors.black.withOpacity(0.5),
+                      builder: (_) => AlertDialog(
+                        backgroundColor: Colors.transparent,
+                        insetPadding: const EdgeInsets.all(24),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        contentPadding: EdgeInsets.zero,
+                        content: const ExchangePointModal(),
+                      ),
+                    );
+                    if (exchanged != null) {
+                      ref.invalidate(homeViewModelProvider);
+                    }
                   },
                   child: Text('ポイントを交換する',
                       style: TextStyle(fontSize: 16.sp), textAlign: TextAlign.center),

--- a/app/lib/features/home/view/widget/exchange_point_modal.dart
+++ b/app/lib/features/home/view/widget/exchange_point_modal.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_container.dart';
+import 'package:app/shared/widget/neumorphic/neumorphic_button.dart';
+import '../../view_model/home_view_model.dart';
+import '../../view_model/training_modal_view_model.dart';
+
+class ExchangePointModal extends ConsumerStatefulWidget {
+  const ExchangePointModal({super.key});
+
+  @override
+  ConsumerState<ExchangePointModal> createState() => _ExchangePointModalState();
+}
+
+class _ExchangePointModalState extends ConsumerState<ExchangePointModal> {
+  int? _selectedAmount;
+  final List<int> _amounts = const [1000, 2000, 3000, 5000, 10000];
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 360),
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: NeumorphicContainer(
+              radius: 20,
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const Text('ポイント交換',
+                      style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+                  const SizedBox(height: 20),
+                  ..._amounts.map(
+                    (amount) => RadioListTile<int>(
+                      title: Text('$amount p'),
+                      value: amount,
+                      groupValue: _selectedAmount,
+                      onChanged: (value) => setState(() => _selectedAmount = value),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  NeumorphicButton(
+                    onPressed: _selectedAmount == null
+                        ? null
+                        : () async {
+                            final confirm = await showDialog<bool>(
+                              context: context,
+                              builder: (_) => AlertDialog(
+                                title: const Text('交換の確認'),
+                                content: Text('${_selectedAmount}pと交換しますか？'),
+                                actions: [
+                                  TextButton(
+                                    onPressed: () => Navigator.of(context).pop(false),
+                                    child: const Text('キャンセル'),
+                                  ),
+                                  TextButton(
+                                    onPressed: () => Navigator.of(context).pop(true),
+                                    child: const Text('はい'),
+                                  ),
+                                ],
+                              ),
+                            );
+                            if (confirm == true) {
+                              final userId = ref.read(homeViewModelProvider).userId;
+                              if (userId == null) return;
+                              final success = await TrainingModalViewModel.submitPointLog(
+                                userId: userId,
+                                pointInfo: 'ポイント交換',
+                                usePoint: _selectedAmount!,
+                              );
+                              if (success && mounted) {
+                                Navigator.of(context).pop(_selectedAmount);
+                              } else {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text('ポイント交換に失敗しました')),
+                                );
+                              }
+                            }
+                          },
+                    child: Text(
+                      '交換する',
+                      style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: _selectedAmount == null ? Colors.grey : Colors.black,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ExchangePointModal` widget for choosing point exchange amount
- open exchange modal from Profile tab and send request to `/update_point`

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d2be94988321ae42adc3dbbd0631